### PR TITLE
Fix RoutingError for clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Add this line to your application's Gemfile:
 ```ruby
 gem 'virtual_sms', group: :development
 ```
-Make sure you have:
-```ruby
-gem 'jquery-rails'
-```
 
 And then execute:
 
@@ -41,5 +37,5 @@ Now, you can go to http://localhost:3000/virtual_sms and check the SMSes!
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
 
 ## Contact
-The project's website is located at https://github.com/emn178/virtual_sms  
+The project's website is located at https://github.com/emn178/virtual_sms
 Author: emn178@gmail.com

--- a/app/views/layouts/virtual_sms/javascripts/_application.html.erb
+++ b/app/views/layouts/virtual_sms/javascripts/_application.html.erb
@@ -6,8 +6,7 @@
 
     var csrfTokenElement = document.querySelector('meta[name="csrf-token"]');
     var csrfToken = csrfTokenElement ? csrfTokenElement.content : null;
-
-    fetch('clear', {
+    fetch(document.querySelector('[data-clear-path]').dataset.clearPath, {
       method: 'DELETE',
       headers: {
         'X-CSRF-Token': csrfToken

--- a/app/views/virtual_sms/messages/index.html.erb
+++ b/app/views/virtual_sms/messages/index.html.erb
@@ -1,4 +1,4 @@
-<a href="javascript: clearMessages()" >Clear</a>
+<a href="javascript: clearMessages()" data-clear-path="<%= clear_messages_path %>">Clear</a>
 <table>
   <colgroup>
     <col width="250px" />


### PR DESCRIPTION
## Issue
When setting up virtual_sms like suggested:
```ruby
mount VirtualSms::Engine => '/virtual_sms'
```

Will cause following error when clicking clear button
```
ActionController::RoutingError (No route matches [DELETE] "/clear")
```
the correct path in this case should be '/virtual_sms/clear'

## Fix proposal
use Rails routes helper `clear_messages` to embed correct path into index page


